### PR TITLE
docs: streamline API reference and add engineering workflow guide

### DIFF
--- a/docs/01-guides/01-first-steps.md
+++ b/docs/01-guides/01-first-steps.md
@@ -52,12 +52,14 @@ print(beam_2.A)
 
 ### Building on the API
 
-The basic usage above relies on `steelsnakes.<region>` imports, but most automated workflows should build on the shared base modules:
+The basic usage above relies on `steelsnakes.<region>` imports. For practical engineering work, that is often the best place to start.
 
-- `steelsnakes.base.database.SectionDatabase` discovers JSON datasets by region, caches every supported `SectionType`, and exposes fuzzy lookups and comparison filters so pipelines can tolerate slight naming variations.
-- `steelsnakes.base.factory.SectionFactory` wires that cache to the concrete classes defined in each region (`UK`, `EU`, `US`, etc.) and exposes `create_section(...)` so you can programmatically assemble any section without hard-coding the class name.
+When your workflow becomes more automated, move to the shared base modules:
 
-See the API reference page (`docs/02-api-reference/02-database.md`) for examples of how the database and factory collaborate, and expect similar patterns to appear in the future for connectors and checks.
+- `steelsnakes.base.database.SectionDatabase` for searching regional catalogues
+- `steelsnakes.base.factory.SectionFactory` for creating typed section objects dynamically
+
+See the **Engineering Workflow** guide and the **Section Database & Factory** reference page for the architecture behind that pattern.
 
 <!-- prettier-ignore-start -->
 !!!warning "Note"

--- a/docs/01-guides/02-engineering-workflow.md
+++ b/docs/01-guides/02-engineering-workflow.md
@@ -1,0 +1,122 @@
+# Engineering Workflow
+
+This guide is for a structural engineer using the app **as it exists today**.
+
+It focuses on practical use, not on a future simplified API.
+
+## The shortest useful mental model
+
+You normally do one of these two things:
+
+- **direct section workflow** for quick checks
+- **database/factory workflow** for automation
+
+```mermaid
+flowchart TD
+    A[Need a section check] --> B{Known section family?}
+    B -->|Yes| C[Direct regional import\nUB / IPE / W / HSS]
+    B -->|No or dynamic| D[SectionDatabase + SectionFactory]
+    C --> E[Read properties]
+    D --> E
+    E --> F[Run regional classification or design check]
+```
+
+## Workflow 1: quick direct use
+
+Use this when you already know the section family.
+
+```python
+from steelsnakes.UK import UB, StressPattern, classify_section
+
+section = UB("457x191x67")
+print(section.h)
+print(section.get_properties())
+
+result = classify_section(
+    section=section,
+    fy_mpa=355.0,
+    stress_pattern=StressPattern.MAJOR_AXIS_BENDING,
+)
+print(result.section_class)
+```
+
+## Workflow 2: dynamic lookup from external data
+
+Use this when designations come from Excel, CSV, databases, or user input.
+
+```python
+from steelsnakes.base.database import SectionDatabase
+from steelsnakes.base.factory import SectionFactory
+from steelsnakes.base.sections import SectionType
+from steelsnakes.UK import classify_section
+
+# Load and search
+uk_db = SectionDatabase(region="UK")
+uk_factory = SectionFactory(database=uk_db)
+
+section = uk_factory.create_section(
+    designation="457x191x67",
+    section_type=SectionType.UB,
+)
+
+# Then run checks
+result = classify_section(section=section, fy_mpa=355.0)
+print(result.section_class)
+```
+
+## What the package is best at today
+
+### 1. Section catalog access
+
+Treat the library as a programmable steel table.
+
+### 2. Classification workflows
+
+The most mature design-oriented workflows in the docs are classification workflows, especially:
+
+- `EU`
+- `UK`
+- `US`
+
+### 3. Scriptable engineering tools
+
+The current architecture is well suited to:
+
+- office scripts
+- engineering notebooks
+- internal web tools
+- spreadsheet-backed automation
+
+## How to think about the architecture
+
+A practical way to explain the app is:
+
+\[
+\text{engineering result} = \text{check}(\text{section geometry},\, \text{material strength},\, \text{design context})
+\]
+
+and `steelsnakes` helps by giving you the section geometry in a structured way.
+
+## Choosing the right entry point
+
+| If you want to... | Start here |
+|---|---|
+| inspect section properties quickly | direct regional import |
+| search a section database | `SectionDatabase` |
+| create typed section objects dynamically | `SectionFactory` |
+| classify an EC3 section | `steelsnakes.EU` or `steelsnakes.UK` |
+| classify an AISC section | `steelsnakes.US` |
+
+## Present limitations to keep in mind
+
+/// card | Important
+- Unit handling is still your responsibility.
+- Coverage varies by region and shape family.
+- Some APIs are engineering-useful but not yet polished as a final public API.
+///
+
+## Recommended reading order
+
+1. **First Steps** for installation and basic property access
+2. **Section Database & Factory** for architecture and automation
+3. **UK / US / EU classification** pages for design workflows

--- a/docs/01-guides/index.md
+++ b/docs/01-guides/index.md
@@ -3,8 +3,9 @@
 ## Overview
 
 1. [First Steps](./01-first-steps.md)
-2. [Codes and Standards](./03-codesandstds.md)
-3. [EU Classification](./05-eu-classification.md)
+2. [Engineering Workflow](./02-engineering-workflow.md)
+3. [Codes and Standards](./03-codesandstds.md)
+4. [EU Classification](./05-eu-classification.md)
 
 $steelsnakes$ is being documented in stages: the core guides collect installation/usage notes and code references, while the standards guide documents which regional specifications the package is lining up with.
 

--- a/docs/02-api-reference/02-database.md
+++ b/docs/02-api-reference/02-database.md
@@ -1,40 +1,116 @@
 # Section Database & Factory
 
-This page captures the shared infrastructure that keeps all regions inside `$steelsnakes$` synchronized: the data caches (`SectionDatabase`) and the wiring layer (`SectionFactory`) that turns cached rows into concrete section objects.
+This is the backbone of the app.
 
-## SectionDatabase
+If you are writing scripts, notebooks, or internal tools, this is usually the most important part of the current architecture.
 
-1. **Discovery & caching.** When you instantiate `SectionDatabase`, it auto-discovers the correct `data/<REGION>/` directory via several fallback paths, optionally respects an injected `data_directory`, and loads every supported `SectionType` into a dictionary cache. Metadata like `_section_type` and `_region` are added to every entry so downstream tools understand the source.
-2. **Fallback SQLite support.** The constructor accepts `use_sqlite=True`, in which case `_load_section_type` can attempt to read from an SQLite table named after each `SectionType` when JSON files are absent. Error handling already logs missing tables and malformed rows without breaking the entire initialization.
-3. **Resilient lookup helpers.** `find_section` first tries an exact match, then `_fuzzy_find_section`:
-   - Exact matches ignore case and normalize separators (` `, `-`, `_`, `×`).
-   - Difflib-based similarity matching provides a controlled suggestion (cutoff 0.8) before falling back to `None`.
-   - `get_similar_sections` can be called independently with `n` suggestions across all loaded types.
-4. **Criteria-based search.** `search_sections(section_type, prop__gt=100, prop__eq="W")` filters the cached dict via comparison operators (`gt`, `lt`, `gte`, `lte`, `eq`, `ne`) and exact matches, so you can quickly find all sections that meet size thresholds.
+## Architecture in one diagram
 
-<!-- prettier-ignore-start -->
-!!! warning "Note"
-    The current database is JSON-first and still mirrors early datasets, so not every region/type has fully verified values. Validate against the source CSV/JSON, especially when drafting code that depends on exact masses or moments of inertia.
-<!-- prettier-ignore-end -->
+```mermaid
+flowchart TD
+    A[region code] --> B[SectionDatabase]
+    B --> C[cache by SectionType]
+    C --> D[find_section / search_sections]
+    C --> E[SectionFactory]
+    E --> F[Concrete section instance]
+    F --> G[get_properties / direct attributes / checks]
+```
 
-## SectionFactory
+## `SectionDatabase`
 
-`SectionFactory` bridges `SectionDatabase` with the concrete section classes.
+`SectionDatabase` does three jobs:
 
-1. **Automatic class loading.** If no `section_classes` mapping is provided, the factory inspects `database.region` and imports the relevant modules (`UK`, `EU`, `US`, `AU`, `NZ` are wired in), while gracefully logging if a region lacks exports.
-2. **Region-aware wiring.** Each helper (e.g., `_load_UK_classes`) imports the region's section definitions (beams, channels, angles, hollow sections) and maps them to `SectionType` members. This keeps the factory thin while letting each region evolve independently.
-3. **Extensibility.** Custom section classes or alternative databases can simply pass their own `section_classes` dict when instantiating the factory, so testing helpers can swap in fake sections without touching the auto-loader.
+1. **find the regional data folder**
+2. **load section tables into memory**
+3. **help you search by designation or filters**
 
-Pair any factory instance with the database you already created to request a section instance:
+### Why it matters
+
+For an engineer, this means you can treat the package like a searchable section catalogue before you even create a section object.
+
+### Typical flow
+
+```python
+from steelsnakes.base.database import SectionDatabase
+
+db = SectionDatabase(region="UK")
+match = db.find_section("457x191x67")
+print(match)
+```
+
+### Search strategy
+
+The lookup behavior is intentionally forgiving:
+
+- exact designation first
+- then normalized matching
+- then fuzzy similarity matching
+
+That is useful when incoming labels vary slightly between spreadsheets, analysis exports, and hand-entered names.
+
+## `SectionFactory`
+
+`SectionFactory` converts cached data into the right regional section class.
+
+### Why it matters
+
+This is what lets you move from **catalogue data** to an **object you can interrogate or classify**.
 
 ```python
 from steelsnakes.base.database import SectionDatabase
 from steelsnakes.base.factory import SectionFactory
 from steelsnakes.base.sections import SectionType
 
-db = SectionDatabase(region="UK")
-factory = SectionFactory(database=db)
-beam = factory.create_section("457x191x67", section_type=SectionType.UB)
+# 1. Load a regional catalogue
+uk_db = SectionDatabase(region="UK")
+
+# 2. Build a factory for that catalogue
+uk_factory = SectionFactory(database=uk_db)
+
+# 3. Create a typed section object
+section = uk_factory.create_section("457x191x67", section_type=SectionType.UB)
+
+print(section)
+print(section.get_properties())
 ```
 
-The next page in this reference dives into the region-specific APIs for UK, EU, US, and additional locales.
+## Practical engineering use
+
+Use the database/factory layer when you need to:
+
+- build a quick section browser
+- validate designations coming from Excel or CSV
+- compare candidate sections with simple filters
+- pass real section objects into classification functions
+
+## Architectural idea
+
+The current architecture is simple enough to explain as:
+
+\[
+\text{section object} = \text{factory}(\text{database}(\text{region data}))
+\]
+
+That may look abstract, but in practice it keeps responsibilities separate:
+
+- data loading stays in one place
+- region-specific shape classes stay in one place
+- design checks stay in one place
+
+## When to use this layer vs direct regional imports
+
+| Use case | Best approach |
+|---|---|
+| You already know the exact class, e.g. `UB` or `W` | Import directly from the region package |
+| You are building a tool that must work from designations dynamically | Use `SectionDatabase` + `SectionFactory` |
+| You need robust lookup from inconsistent names | Start with `SectionDatabase` |
+| You want classification after lookup | Database → Factory → Check |
+
+## Minimal rule of thumb
+
+/// card | Recommended pattern
+For exploratory engineering work:
+
+1. use a **regional direct import** for quick one-off checks
+2. use **database + factory** for automation or apps
+///

--- a/docs/02-api-reference/03-us-classification.md
+++ b/docs/02-api-reference/03-us-classification.md
@@ -1,54 +1,104 @@
 # US Classification
 
-This page documents the current AISC local-buckling classification API in `steelsnakes.US`.
+This page documents the current AISC classification surface in `steelsnakes.US`.
 
-## Cross-Code Naming Note
+The goal here is not to mirror every function in prose. The goal is to make the structure easy to use.
 
-`StressPattern` is intentionally kept as a shared public name across regions so callers can reuse a familiar API shape.
+## What the module does
 
-Its meaning is not identical in every code:
+The US classification module evaluates local slenderness / compactness style limits for the relevant compression elements.
 
-- In **EU / EC3**, `StressPattern` is closer to an element stress-case selector.
-- In **US / AISC B4.1**, `StressPattern` is better understood as the **classification context** that determines which compression element and which table case apply.
+In practice, the workflow is:
 
-For US code, `StressPattern` is therefore an alias of `ClassificationContext`.
+```mermaid
+flowchart LR
+    A[section or ratios] --> B[Classification context]
+    B --> C[Select AISC Table B4.1 case]
+    C --> D[Classify each active element]
+    D --> E[Return governing result]
+```
 
-## Shared Principle
+## Core idea
 
-The order of reasoning differs slightly by code, but the underlying idea is the same:
+In the US implementation, the starting point is usually the **classification context**.
 
-- In **EU**, the implementation starts from the section elements and then applies the relevant force or stress case to each element.
-- In **US**, the implementation starts from the member action or classification context and then selects which element and which Table B4.1 case are active.
+That context decides which element is active and which case is checked.
 
-In both codes, the core principle is still:
+So the mental model is:
 
-1. identify the relevant plate element in compression
-2. identify the correct code-specific classification rule for that element
-3. classify the element
-4. let the governing element determine the section classification
+\[
+\text{result} = f(\text{context},\, \lambda,\, F_y,\, E,\, \text{case metadata})
+\]
 
-## Scope Notes
+where \(\lambda\) is the relevant slenderness ratio for the active plate or wall.
 
-Some AISC cases are intentionally available through the direct case API before they are auto-wired to a section adapter:
+## Use the API at three levels
 
-- cover-plate cases such as `CompressionCase.CASE_7` and `FlexureCase.CASE_18`
-- built-up or singly symmetric cases that need extra metadata
-- fabricated box-section cases that do not yet have their own section family in the library
+### 1. Fast section-level check
 
-## Case Enums
+Use this when you already have a `steelsnakes.US` section object.
 
-US users can now work with either:
+```python
+from steelsnakes.US.checks import classify_section, ClassificationContext
 
-- string values such as `"case1"` and `"case10"`
-- enum values such as `CompressionCase.CASE_1` and `FlexureCase.CASE_10`
+result = classify_section(
+    section=section,
+    context=ClassificationContext.COMPRESSION,
+    Fy=50.0,
+)
+```
 
-Each enum exposes:
+### 2. Dictionary-based check
 
-- `.value` for the string form used by the functions
-- `.label` as a readable alias of that string
-- `.description` as a short guide to the corresponding AISC Table B4.1 case
+Use this for API payloads, spreadsheets, or serializers.
 
-## API Reference
+```python
+from steelsnakes.US.checks import classify_section_from_dict
+
+result = classify_section_from_dict(
+    data=section_data,
+    context="compression",
+    Fy=50.0,
+)
+```
+
+### 3. Direct case check
+
+Use this when you need exact control over the AISC table case.
+
+```python
+from steelsnakes.US.checks import classify_compression, CompressionCase
+
+result = classify_compression(
+    CompressionCase.CASE_1,
+    ratio=38.2,
+    Fy=50.0,
+    E=29000.0,
+)
+```
+
+## Which objects matter most
+
+| Object | Use it for |
+|---|---|
+| `ClassificationContext` | Tell the module what design situation you are checking |
+| `CompressionCase`, `FlexureCase` | Force a specific AISC case |
+| `ElementInput` | Provide explicit element-level inputs |
+| `ClassificationResult` | Read the governing section/element result |
+
+## Recommended usage for engineers
+
+- Use **section-level classification** first.
+- Drop to **dictionary input** when integrating with external data.
+- Drop to **direct case functions** only when you are validating edge cases or building your own adapter.
+
+## Scope note
+
+The API is already useful, but some cases are exposed sooner at the direct-case level than at the high-level adapter level.
+
+That is a normal consequence of the current architecture and is acceptable for an engineering-first release.
+
+## API objects
 
 ::: steelsnakes.US.checks.classification.StressPattern
 

--- a/docs/02-api-reference/04-uk-classification.md
+++ b/docs/02-api-reference/04-uk-classification.md
@@ -1,41 +1,32 @@
 # UK Classification
 
-This page documents the current UK classification API in `steelsnakes.UK`.
+This page documents the current UK classification surface in `steelsnakes.UK`.
 
-## Design Goal
+The UK package is best understood as a **regional adapter over the shared EC3-style engine**.
 
-The UK module reuses the shared EC3 classification engine from `steelsnakes.EU` and adapts it through UK section families.
+## Architecture in one view
 
-That keeps the backend formula logic centralized while still giving the UK package a complete public API.
+```mermaid
+flowchart LR
+    A[UK section class] --> B[classification_elements or section adapter]
+    B --> C[shared EC3 classification logic]
+    C --> D[element classes]
+    D --> E[governing section class]
+```
 
-## What Reuses Directly
+## Design idea
 
-The same EN 1993-1-1 Table 5.2 helpers are reused for:
+The formula logic stays centralized, while the UK package supplies the section families and public entry points engineers actually want to import.
 
-- `UB`, `UC`, and `UBP`
-- `PFC`
-- equal and unequal angles
-- back-to-back angle variants
-- hot-finished `HFRHS`, `HFSHS`, and `HFCHS`
-- cold-formed `CFRHS`, `CFSHS`, and `CFCHS` through the same shared engine, with explicit Class 4 exits
+That makes the current architecture:
 
-The UK package exports the same main helpers as the EU package:
+- easier to extend
+- easier to test
+- easier to keep aligned with the EU implementation
 
-- `classify_section()`
-- `classify_section_from_dict()`
-- `classify_circular_hollow()`
-- `classify_internal_part()`
-- `classify_outstand_flange()`
-- `ElementInput`
-- `ElementStressCase`
-- `StressPattern`
+## What to use first
 
-These are available from both:
-
-- `steelsnakes.UK.checks`
-- `steelsnakes.UK`
-
-## Common Usage
+### 1. Standard section check
 
 ```python
 from steelsnakes.UK import UB, StressPattern, classify_section
@@ -48,11 +39,9 @@ result = classify_section(
 )
 
 print(result.section_class)
-for element in result.elements:
-    print(element.name, element.stress, element.section_class)
 ```
 
-Hollow sections use the same public entry point:
+### 2. Hollow section check
 
 ```python
 from steelsnakes.UK import HFRHS, classify_section
@@ -63,23 +52,64 @@ result = classify_section(section=section, fy_mpa=355.0)
 print(result.section_class)
 ```
 
-## Scope Notes
+### 3. Explicit element-level control
 
-The UK classification surface is intentionally aligned with the EU API, and now includes the following hollow families:
+Use `custom_elements` when you want to control the stress state directly.
 
-| Section family | Status | Notes |
-|----------------|--------|-------|
-| `HFRHS` | Supported | Table 5.2 Sheet 1; uses `cw_t` / `cf_t` |
-| `HFSHS` | Supported | Table 5.2 Sheet 1; uses `c_t` |
-| `HFCHS` | Supported | Table 5.2 Sheet 3; uses `d_t` and the `e^2 = 235 / fy` rule |
-| `CFRHS` | Supported | Table 5.2 Sheet 1; Class 4 raises and points to `EN 1993-1-3` |
-| `CFSHS` | Supported | Table 5.2 Sheet 1; Class 4 raises and points to `EN 1993-1-3` |
-| `CFCHS` | Supported | Table 5.2 Sheet 3; Class 4 raises and points to `EN 1993-1-3` |
-| `HFEHS` | Deferred | No EN 1993-1-1 Table 5.2 rule is implemented |
+```python
+from steelsnakes.UK import ElementInput, ElementStressCase, classify_section
 
-When you need full manual control, pass `custom_elements` to `classify_section(...)`.
+result = classify_section(
+    fy_mpa=355.0,
+    custom_elements=[
+        ElementInput(
+            name="web",
+            kind="internal",
+            c_mm=360.4,
+            t_mm=7.7,
+            stress=ElementStressCase.COMBINED,
+            alpha=0.70,
+        )
+    ],
+)
+```
 
-## API Reference
+## Engineering interpretation
+
+For a structural engineer, the useful pattern is:
+
+1. instantiate a UK section
+2. pick the stress pattern that matches the design situation
+3. read the governing element class
+
+In compact notation:
+
+\[
+\text{section class} = \max\left(\text{element classes derived from Table 5.2 logic}\right)
+\]
+
+where “max” means the most restrictive class governs.
+
+## Supported shape families
+
+| Family | Status | Note |
+|---|---|---|
+| `UB`, `UC`, `UBP` | Supported | Main I/H section workflow |
+| `PFC` | Supported | Channel workflow |
+| Angles | Supported | Compression-oriented use cases are in place |
+| `HFRHS`, `HFSHS`, `HFCHS` | Supported | Hot-finished hollow sections |
+| `CFRHS`, `CFSHS`, `CFCHS` | Supported | Shared engine, with explicit Class 4 exits |
+| `HFEHS` | Deferred | No implemented Table 5.2 path yet |
+
+## Recommended usage for engineers
+
+/// card | Recommended order
+1. Use `classify_section(...)` for normal work.
+2. Use `StressPattern` presets for common beam/column situations.
+3. Use `custom_elements` only when you need explicit stress control.
+///
+
+## API objects
 
 ::: steelsnakes.UK.checks.classification.StressPattern
 

--- a/docs/02-api-reference/index.md
+++ b/docs/02-api-reference/index.md
@@ -1,19 +1,63 @@
 # API Reference
 
-The reference is split into the shared base modules that power all regions, followed by the region-specific packages that tailor steel sections, databases, factories, and checks to each code.
+This reference is intentionally **lean**.
 
-## Base Modules
+Use it to answer three questions quickly:
 
-1. `sections` provides the `SectionType` enumerations plus the abstract `BaseSection`. Every concrete section class inherits the helpers (`get_properties`, `list_properties`, `from_dictionary`) so consumers can enumerate attributes consistently.
-2. `database` explains how JSON datasets are auto-discovered, cached, and exposed through fuzzy search, comparison filtering, and similarity helpers for resilient designation lookups.
-3. `factory` maps the cached data to region-aware section classes, auto-loading UK/EU/US modules and warning when a region does not yet have a concrete implementation.
-4. `checks` holds shared limit-state helpers; current coverage includes EC3 classification (UK/EU), UK ULS and stability helpers, and AISC LRFD/classification.
+1. **Where does data come from?** `SectionDatabase`
+2. **How do I get a section object?** `SectionFactory`
+3. **Where do classification checks live?** Regional `checks` modules
 
-## Regions
+/// card | Core architecture
+`steelsnakes` currently has a practical internal architecture:
 
-1. `UK`
-2. `EU`
-3. `US` and `US_Metric`
-4. `IN`
+- **data files** hold section properties
+- **database classes** load and search them
+- **factory classes** build section objects
+- **regional section classes** expose geometry/properties
+- **regional checks** perform code-specific verification
+///
 
-Each region still provides its own `sections`, `database`, `factory`, and `checks` modules. Check the corresponding regional README files and API pages to see exactly which standards and section profiles are currently packaged.
+## Mental model
+
+```mermaid
+flowchart LR
+    A[JSON section tables] --> B[SectionDatabase]
+    B --> C[SectionFactory]
+    C --> D[Regional section class\nUB / IPE / W / HSS]
+    D --> E[Checks module\nEU / UK / US]
+    E --> F[Classification or design result]
+```
+
+## Package layout
+
+| Layer | Main modules | Why it exists |
+|---|---|---|
+| Shared core | `steelsnakes.base.sections`, `steelsnakes.base.database`, `steelsnakes.base.factory` | Common section typing, data loading, lookup, and object creation |
+| Regional data | `steelsnakes.<region>.data` | Region-specific section tables |
+| Regional sections | `steelsnakes.<region>.sections` | Concrete classes such as `UB`, `UC`, `IPE`, `W`, `HSS` |
+| Regional checks | `steelsnakes.EU.checks`, `steelsnakes.UK.checks`, `steelsnakes.US.checks` | Code-specific classification and design helpers |
+
+## What to read next
+
+- **Section Database & Factory** if you are automating section lookup, data access, or object creation.
+- **UK Classification** if you are using EC3-style classification through the UK package.
+- **US Classification** if you are using AISC local slenderness / compactness checks.
+
+## Current public API stance
+
+The current API is best understood as a **working engineering API**, not yet a final polished public interface.
+
+That means:
+
+- the **architecture is already useful** for scripts and engineering workflows
+- the **classification entry points are usable today**
+- a simpler, more unified public API can still be added later without losing the current structure
+
+A good rule is:
+
+\[
+\text{workflow today} = \text{data access} + \text{section object} + \text{regional check}
+\]
+
+That is the pattern this documentation now emphasizes.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -115,7 +115,9 @@ nav:
   - Guides:
     - Overview: 01-guides/index.md
     - First Steps: 01-guides/01-first-steps.md
+    - Engineering Workflow: 01-guides/02-engineering-workflow.md
     - Codes and Standards: 01-guides/03-codesandstds.md
+    - Classification Architecture Decision: 01-guides/04-classification-architecture-decision.md
     - EU Classification: 01-guides/05-eu-classification.md
   - API Reference:
     - Overview: 02-api-reference/index.md


### PR DESCRIPTION
### Motivation

- Make the API Reference leaner and architecture-focused so engineers can find the core workflow quickly. 
- Provide concise, practical guidance for using the library today (database → factory → regional checks) rather than a long prose reference. 
- Add a short engineering-focused guide that explains when to use direct regional imports vs the database/factory path. 

### Description

- Rewrote the API Reference landing page to an architecture-first, concise overview with a Mermaid mental-model diagram and a compact package layout (file: `docs/02-api-reference/index.md`).
- Reworked the Section Database & Factory reference into a practical, example-driven page that explains `SectionDatabase` and `SectionFactory` usage and search strategies (file: `docs/02-api-reference/02-database.md`).
- Simplified and tightened the UK and US classification pages to emphasize engineering workflows, recommended usage patterns, and kept the autodoc API objects (files: `docs/02-api-reference/04-uk-classification.md`, `docs/02-api-reference/03-us-classification.md`).
- Added a new `Engineering Workflow` guide for structural engineers with Mermaid diagrams, LaTeX framing, and concrete direct vs dynamic lookup examples (file: `docs/01-guides/02-engineering-workflow.md`).
- Small edits to onboarding (`docs/01-guides/01-first-steps.md`) and updated the MkDocs navigation to surface the new guide and keep the architecture decision page (file: `mkdocs.yaml`).
- Documentation changes use Mermaid diagrams, LaTeX expressions, and mkdocs-shadcn card/snippet styles to keep pages compact and readable; the existing mkdocstrings directives for API objects were preserved.

### Testing

- Built the documentation with `PYTHONPATH=src mkdocs build --strict` and the build completed successfully. 
- No unit tests or runtime code changes were modified by this PR; only documentation files and site navigation were updated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69beab65db28832cb0fa37b872e860f2)